### PR TITLE
채팅 배지 컴포넌트 생성, div 태그를 시맨틱태그로 수정

### DIFF
--- a/src/components/common/ChattingBadge.tsx
+++ b/src/components/common/ChattingBadge.tsx
@@ -1,0 +1,9 @@
+const ChattingBadge = () => {
+  return (
+    <div className="badge border-0 bg-black-primary text-white w-[62px] h-[30px]">
+      채팅중
+    </div>
+  );
+};
+
+export default ChattingBadge;

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -1,10 +1,9 @@
-import React from "react";
 import { Link } from "react-router-dom";
 import { AiFillGithub } from "react-icons/ai";
 
 const Footer = (): JSX.Element => {
   return (
-    <div className="w-full bg-black-primary flex flex-row items-center justify-center h-24">
+    <footer className="w-full bg-black-primary flex flex-row items-center justify-center h-24">
       <Link
         to="https://github.com/winnow-2023?tab=repositories"
         target="_blank"
@@ -15,7 +14,7 @@ const Footer = (): JSX.Element => {
       <p className="text-white text-xs font-light">
         Copyright © 2023 Best-Choice All rights reserved
       </p>
-    </div>
+    </footer>
   );
 };
 

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -10,9 +10,9 @@ const Header = (): JSX.Element => {
   ];
 
   return (
-    <div className="w-ful bg-white flex flex-row items-center h-[70px] shadow-md">
-      <div className="xl:container mx-auto flex flex-row justify-between">
-        <div>
+    <header className="w-ful bg-white flex flex-row items-center h-[70px] shadow-md">
+      <div className="xl:container px-12 mx-auto flex flex-row justify-between">
+        <nav>
           <Link to="/" className="mr-10">
             로고
           </Link>
@@ -21,13 +21,13 @@ const Header = (): JSX.Element => {
               to={`/${menu.name}`}
               key={menu.name}
               className={`text-base mr-6 ${
-                menu.name === "hot" ? "font-semibold" : ""
+                menu.name === "hot" ? "font-bold" : ""
               }`}
             >
               {menu.title}
             </Link>
           ))}
-        </div>
+        </nav>
         <div className="flex flex-row items-center">
           <Link to="/notification" className="text-2xl ml-6">
             <IoMdNotificationsOutline />
@@ -37,7 +37,7 @@ const Header = (): JSX.Element => {
           </Link>
         </div>
       </div>
-    </div>
+    </header>
   );
 };
 

--- a/src/components/common/PeopleBadge.tsx
+++ b/src/components/common/PeopleBadge.tsx
@@ -1,0 +1,14 @@
+import { AiOutlineUser } from "react-icons/ai";
+
+const PeopleBadge = () => {
+  return (
+    <div className="badge border-0 bg-black-primary w-[62px] h-[30px]">
+      <div className="text-white text-lg">
+        <AiOutlineUser />
+      </div>
+      <div className="text-white text-base ml-1">9</div>
+    </div>
+  );
+};
+
+export default PeopleBadge;


### PR DESCRIPTION
## PR Type
- [x] Feat: 새로운 기능 구현
- [ ] Fix: 버그 수정
- [ ] Docs: 문서 추가 및 수정
- [ ] Style: 코드 포맷 변경
- [ ] Design: css 및 UI 관련 변경
- [x] Refactor: 코드 리팩토링
- [ ] Rename: 폴더/파일 이름 및 위치 변경
- [ ] Test: 테스트 관련
- [ ] Deploy: 배포 관련
- [ ] Chore: 빌드, 환경 설정 등 기타 작업
- [ ] Add: 기능 구현 외 추가 사항

## Abstracts
* 채팅 관련 배지 컴포넌트 만들고 헤더, 푸터의 div 태그를 시맨틱태그로 수정했습니다~

## Description
- 채팅중, 채팅인원 배지 컴포넌트 생성
- header 콘텐츠 영역에 패딩 적용
- div 태그 -> header, nav, footer 시맨틱 태그로 수정

## Discussion
*

---
