### PR TITLE
메인페이지 채팅방 컴포넌트 구현, 채팅인원 배지 컴포넌트 이름 변경, msw 데이터 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Best Choice</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/MainChattingList.tsx
+++ b/src/components/MainChattingList.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import axios from "axios";
+import ChatUserBadge from "./common/ChatUserBadge";
+import { Post } from "../mocks/mockDatas/activeChatListData";
+
+const MainChattingList = (): JSX.Element => {
+  const [chatRoomData, setChatRoomData] = useState<Post[]>([]);
+
+  const getData = async () => {
+    try {
+      const response = await axios.get("/activeChatListData");
+      const data = response.data["content"];
+      setChatRoomData(data);
+    } catch (error) {
+      console.error("채팅방 리스트 가져오는 중 오류 발생:", error);
+    }
+  };
+
+  useEffect(() => {
+    getData();
+  }, []);
+
+  return (
+    <>
+      <div className="flex gap-x-6">
+        {chatRoomData.slice(0, 4).map((data) => (
+          <div
+            key={data.postId}
+            onClick={() => console.log("모달")}
+            className="flex flex-col border border-blue border-2 rounded-xl bg-white w-[258px] h-[180px] shrink-0 p-2.5 cursor-pointer"
+          >
+            <div className="flex justify-end mb-2">
+              <ChatUserBadge ChatUserCount={data.liveChatUserCount} />
+            </div>
+            <p className="text-lg text-center font-semibold p-4">
+              {data.title}
+            </p>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default MainChattingList;

--- a/src/components/common/ChatUserBadge.tsx
+++ b/src/components/common/ChatUserBadge.tsx
@@ -1,14 +1,18 @@
 import { AiOutlineUser } from "react-icons/ai";
 
-const PeopleBadge = () => {
+const ChatUserBadge = ({
+  ChatUserCount,
+}: {
+  ChatUserCount: number | undefined;
+}) => {
   return (
     <div className="badge border-0 bg-black-primary w-[62px] h-[30px]">
       <div className="text-white text-lg">
         <AiOutlineUser />
       </div>
-      <div className="text-white text-base ml-1">9</div>
+      <div className="text-white text-base ml-1">{ChatUserCount}</div>
     </div>
   );
 };
 
-export default PeopleBadge;
+export default ChatUserBadge;

--- a/src/mocks/mockDatas/activeChatListData.ts
+++ b/src/mocks/mockDatas/activeChatListData.ts
@@ -3,7 +3,7 @@ type Member = {
   nickname: string;
 };
 
-type Post = {
+export type Post = {
   postId: number;
   member: Member;
   title: string;
@@ -16,7 +16,8 @@ type Post = {
   heartCount: number;
   choiceCount: number;
   commentCount: number;
-  liveChatUserCount: number;
+  chattingActive?: boolean;
+  liveChatUserCount?: number;
 };
 
 type Pageable = {
@@ -45,27 +46,27 @@ export const activeChatListData: ActiveChatListData = {
     {
       postId: 2,
       member: { memberId: 2, nickname: "person2" },
-      title: "학교에 대한 질문",
-      content: "학교에 대한 질문입니다.",
-      optionA: "원격 수업이 좋다",
-      optionB: "대면 수업이 좋다.",
-      tag: ["공부", "학교"],
-      createdDate: "2023.08.02",
+      title: "소개팅 장소 어디가 좋을까요?",
+      content: "분위기 좋은 카페와 레스토랑 중에 고민 중인데 어디로 잡을까요?",
+      optionA: "카페",
+      optionB: "레스토랑",
+      tag: ["데이트", "소개팅"],
+      createdDate: "2023.08.10",
       popoularityDate: null,
-      heartCount: 14,
-      choiceCount: 20,
-      commentCount: 5,
-      liveChatUserCount: 6,
+      heartCount: 0,
+      choiceCount: 0,
+      commentCount: 0,
+      liveChatUserCount: 9,
     },
     {
       postId: 5,
       member: { memberId: 5, nickname: "person5" },
-      title: "긴팔 아니면 반팔",
-      content: "요즘 날씨에 어울리는 옷은?",
+      title: "요즘 날씨에 어울리는 옷은?",
+      content: "긴팔 입을까 반팔 입을까",
       optionA: "긴팔",
       optionB: "반팔",
       tag: ["코디", "날씨"],
-      createdDate: "2023.08.10",
+      createdDate: "2023.08.11",
       popoularityDate: null,
       heartCount: 10,
       choiceCount: 10,
@@ -105,8 +106,8 @@ export const activeChatListData: ActiveChatListData = {
     {
       postId: 11,
       member: { memberId: 11, nickname: "person11" },
-      title: "쇼미더머니 지원 영상 보내기 vs 미스터트롯 출연",
-      content: "랩에 소실 없음 그리고 트로트로 소질 없음",
+      title: "쇼미더머니 지원 영상 올리기 vs 미스터트롯 출연",
+      content: "랩에 소질 없음 트로트도 소질 없음",
       optionA: "쇼미더머니",
       optionB: "미스터트롯",
       tag: ["밸런스"],
@@ -116,6 +117,21 @@ export const activeChatListData: ActiveChatListData = {
       choiceCount: 50,
       commentCount: 10,
       liveChatUserCount: 9,
+    },
+    {
+      postId: 12,
+      member: { memberId: 12, nickname: "person12" },
+      title: "1주일 동안 삼시세끼 치킨만 먹기 vs 3년 동안 치킨 못 먹기",
+      content: "1주일 동안 삼시세끼 꼬박꼬박 치킨만 먹어야함.",
+      optionA: "3년 동안 치킨 못 먹기",
+      optionB: "삼시세끼 치킨 먹기",
+      tag: ["밸런스"],
+      createdDate: "2023.08.16",
+      popoularityDate: null,
+      heartCount: 0,
+      choiceCount: 0,
+      commentCount: 0,
+      liveChatUserCount: 6,
     },
     {
       postId: 13,
@@ -141,7 +157,7 @@ export const activeChatListData: ActiveChatListData = {
       optionA: "안읽씹이 더 별로다",
       optionB: "읽씹이 더 별로다.",
       tag: ["연락"],
-      createdDate: "2023.08.16",
+      createdDate: "2023.08.17",
       popoularityDate: null,
       heartCount: 0,
       choiceCount: 0,
@@ -156,7 +172,7 @@ export const activeChatListData: ActiveChatListData = {
       optionA: "1년 내내 여름",
       optionB: "1년 내내 겨울",
       tag: ["계절"],
-      createdDate: "2023.08.16",
+      createdDate: "2023.08.17",
       popoularityDate: null,
       heartCount: 0,
       choiceCount: 0,
@@ -166,17 +182,17 @@ export const activeChatListData: ActiveChatListData = {
     {
       postId: 16,
       member: { memberId: 16, nickname: "person16" },
-      title: "소개팅 장소 어디가 좋을까요?",
-      content: "분위기 좋은 카페와 레스토랑 중에 고민 중인데 어디로 잡을까요?",
-      optionA: "카페",
-      optionB: "레스토랑",
-      tag: ["데이트", "소개팅"],
-      createdDate: "2023.08.16",
+      title: "학교에 대한 질문",
+      content: "학교에 대한 질문입니다.",
+      optionA: "원격 수업이 좋다",
+      optionB: "대면 수업이 좋다.",
+      tag: ["공부", "학교"],
+      createdDate: "2023.08.17",
       popoularityDate: null,
-      heartCount: 0,
-      choiceCount: 0,
-      commentCount: 0,
-      liveChatUserCount: 9,
+      heartCount: 14,
+      choiceCount: 20,
+      commentCount: 5,
+      liveChatUserCount: 6,
     },
     {
       postId: 17,
@@ -186,7 +202,7 @@ export const activeChatListData: ActiveChatListData = {
       optionA: "4개국어 현지인 수준으로 가능",
       optionB: "다른 사람 속마음 읽기(모르는 언어면 못 읽음)",
       tag: ["능력"],
-      createdDate: "2023.08.16",
+      createdDate: "2023.08.18",
       popoularityDate: null,
       heartCount: 0,
       choiceCount: 0,
@@ -201,7 +217,7 @@ export const activeChatListData: ActiveChatListData = {
       optionA: "노래 천재",
       optionB: "춤 천재",
       tag: ["밸런스"],
-      createdDate: "2023.08.16",
+      createdDate: "2023.08.18",
       popoularityDate: null,
       heartCount: 0,
       choiceCount: 0,
@@ -216,7 +232,7 @@ export const activeChatListData: ActiveChatListData = {
       optionA: "100% 확률로 1000만원 받기",
       optionB: "30% 확률로 1억 받기",
       tag: ["밸런스"],
-      createdDate: "2023.08.16",
+      createdDate: "2023.08.19",
       popoularityDate: null,
       heartCount: 0,
       choiceCount: 0,

--- a/src/mocks/mockDatas/postListData.ts
+++ b/src/mocks/mockDatas/postListData.ts
@@ -16,7 +16,8 @@ export type Post = {
   heartCount: number;
   choiceCount: number;
   commentCount: number;
-  chattingActive: boolean;
+  chattingActive?: boolean;
+  liveChatUserCount?: number;
 };
 
 type Pageable = {
@@ -60,16 +61,16 @@ export const postListData: PostListData = {
     {
       postId: 2,
       member: { memberId: 2, nickname: "person2" },
-      title: "학교에 대한 질문",
-      content: "학교에 대한 질문입니다.",
-      optionA: "원격 수업이 좋다",
-      optionB: "대면 수업이 좋다.",
-      tag: ["공부", "학교"],
-      createdDate: "2023.08.02",
+      title: "소개팅 장소 어디가 좋을까요?",
+      content: "분위기 좋은 카페와 레스토랑 중에 고민 중인데 어디로 잡을까요?",
+      optionA: "카페",
+      optionB: "레스토랑",
+      tag: ["데이트", "소개팅"],
+      createdDate: "2023.08.10",
       popoularityDate: null,
-      heartCount: 14,
-      choiceCount: 20,
-      commentCount: 5,
+      heartCount: 0,
+      choiceCount: 0,
+      commentCount: 0,
       chattingActive: true,
     },
     {
@@ -80,7 +81,7 @@ export const postListData: PostListData = {
       optionA: "친구랑",
       optionB: "혼자",
       tag: ["여행"],
-      createdDate: "2023.08.05",
+      createdDate: "2023.08.10",
       popoularityDate: null,
       heartCount: 4,
       choiceCount: 10,
@@ -95,7 +96,7 @@ export const postListData: PostListData = {
       optionA: "도와줄 수 있다.",
       optionB: "절대 안 된다.",
       tag: ["연애"],
-      createdDate: "2023.08.07",
+      createdDate: "2023.08.11",
       popoularityDate: "2023.8.15",
       heartCount: 50,
       choiceCount: 100,
@@ -105,12 +106,12 @@ export const postListData: PostListData = {
     {
       postId: 5,
       member: { memberId: 5, nickname: "person5" },
-      title: "긴팔 아니면 반팔",
-      content: "요즘 날씨에 어울리는 옷은?",
+      title: "요즘 날씨에 어울리는 옷은?",
+      content: "긴팔 입을까 반팔 입을까",
       optionA: "긴팔",
       optionB: "반팔",
       tag: ["코디", "날씨"],
-      createdDate: "2023.08.10",
+      createdDate: "2023.08.11",
       popoularityDate: null,
       heartCount: 10,
       choiceCount: 10,
@@ -125,7 +126,7 @@ export const postListData: PostListData = {
       optionA: "라면",
       optionB: "피자",
       tag: ["음식"],
-      createdDate: "2023.08.10",
+      createdDate: "2023.08.11",
       popoularityDate: null,
       heartCount: 20,
       choiceCount: 30,
@@ -185,7 +186,7 @@ export const postListData: PostListData = {
       optionA: "딱복",
       optionB: "말복",
       tag: ["밸런스"],
-      createdDate: "2023.08.16",
+      createdDate: "2023.08.15",
       popoularityDate: "2023.08.22",
       heartCount: 60,
       choiceCount: 120,
@@ -195,8 +196,8 @@ export const postListData: PostListData = {
     {
       postId: 11,
       member: { memberId: 11, nickname: "person11" },
-      title: "쇼미더머니 지원 영상 보내기 vs 미스터트롯 출연",
-      content: "랩에 소실 없음 그리고 트로트로 소질 없음",
+      title: "쇼미더머니 지원 영상 올리기 vs 미스터트롯 출연",
+      content: "랩에 소질 없음 트로트도 소질 없음",
       optionA: "쇼미더머니",
       optionB: "미스터트롯",
       tag: ["밸런스"],

--- a/src/views/MainPage.tsx
+++ b/src/views/MainPage.tsx
@@ -1,7 +1,12 @@
-import React from "react";
+import MainChattingList from "../components/MainChattingList";
 
 const MainPage = (): JSX.Element => {
-  return <div>MainPage!</div>;
+  return (
+    <>
+      <div className="text-2xl font-semibold mb-8">진행 중인 채팅방</div>
+      <MainChattingList />
+    </>
+  );
 };
 
 export default MainPage;


### PR DESCRIPTION
## PR Type
- [x] Feat: 새로운 기능 구현
- [ ] Fix: 버그 수정
- [ ] Docs: 문서 추가 및 수정
- [ ] Style: 코드 포맷 변경
- [ ] Design: css 및 UI 관련 변경
- [x] Refactor: 코드 리팩토링
- [x] Rename: 폴더/파일 이름 및 위치 변경
- [ ] Test: 테스트 관련
- [ ] Deploy: 배포 관련
- [ ] Chore: 빌드, 환경 설정 등 기타 작업
- [ ] Add: 기능 구현 외 추가 사항

## Abstracts
* 메인 페이지 채팅방 컴포넌트 구현하고, 채팅인원 배지 컴포넌트 이름 변경, msw 데이터 일부 수정했습니다!

## Description
- 채팅방/투표글 데이터 Post 타입에 채팅중 여부, 채팅 인원 수 옵셔널로 수정
- PeopleBadge -> ChatUserBadge로 컴포넌트명 변경 (데이터 컬럼 이름과 맞춤)
- 채팅 인원 데이터 props로 받아오도록 구현
- index.html 파일 lang, title 수정
- 메인페이지에 채팅방 컴포넌트 생성 및 데이터 연결

## Discussion
* 투표글 데이터, 채팅 리스트 데이터들 날짜 수정하고 일부 데이터 순서 변경했습니당

---
