### PR TITLE
헤더 상단에 고정 및 스크롤 탑 이동 버튼 구현, 채팅방 입장 모달 오류 및 탭 포커스 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ function App() {
   return (
     <BrowserRouter>
       <Header />
-      <section className="main pt-20 pb-24 px-4 md:px-12 mx-auto xl:container">
+      <section className="main pt-12 md:pt-20 pb-24 px-4 md:px-12 mx-auto xl:container">
         <Router />
       </section>
       <Footer />

--- a/src/components/MainChattingList.tsx
+++ b/src/components/MainChattingList.tsx
@@ -44,7 +44,8 @@ const MainChattingList = (): JSX.Element => {
               <div
                 key={data.postId}
                 onClick={() => openModal(data)}
-                className="flex flex-col border border-blue border-2 rounded-xl bg-white w-full h-[180px] shrink-0 p-2.5 cursor-pointer"
+                className="border border-blue border-2 rounded-xl bg-white w-full h-[180px] shrink-0 p-2.5 cursor-pointer"
+                tabIndex={0}
               >
                 <div className="flex justify-end mb-2">
                   <ChatUserBadge ChatUserCount={data.liveChatUserCount} />

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -24,7 +24,7 @@ const Header = (): JSX.Element => {
 
   return (
     <>
-      <header className="w-full bg-white flex items-center h-[70px] shadow-md">
+      <header className="sticky top-0 w-full bg-white flex items-center h-[70px] shadow-md">
         <div className="w-full xl:container px-4 md:px-12 md:mx-auto flex flex-row justify-between">
           <nav>
             <div className="md:hidden flex items-center">

--- a/src/components/common/ScrollTopBtn.tsx
+++ b/src/components/common/ScrollTopBtn.tsx
@@ -1,0 +1,47 @@
+import styled from "styled-components";
+import { IoMdArrowRoundUp } from "react-icons/io";
+
+const TopBtn = styled.button`
+  position: fixed;
+  bottom: 0px;
+  right: 30px;
+  transform: translateY(-50%);
+  width: 60px;
+  height: 60px;
+  background-color: rgba(255, 255, 255, 0.9);
+  border-radius: 50%;
+  text-align: center;
+  color: #1c1c1c;
+  box-shadow: 0 10px 10px 0 rgba(0, 0, 0, 0.2);
+  cursor: pointer;
+  z-index: 40;
+  @media (min-width: 1344px) {
+    left: 50%;
+    transform: translateX(582px) translateY(-50%);
+  }
+`;
+
+const ScrollTopBtn = (): JSX.Element => {
+  const handleClick = () => {
+    if (!window.scrollY) return;
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  };
+
+  return (
+    <>
+      <TopBtn onClick={handleClick}>
+        <div className="flex flex-col items-center">
+          <div className="text-2xl">
+            <IoMdArrowRoundUp />
+          </div>
+          <span className="text-sm tracking-wide">TOP</span>
+        </div>
+      </TopBtn>
+    </>
+  );
+};
+
+export default ScrollTopBtn;

--- a/src/components/contents/PostCardList.tsx
+++ b/src/components/contents/PostCardList.tsx
@@ -34,13 +34,16 @@ const PostCardList = ({
                 key={sortName.name}
                 className="cursor-pointer"
                 onClick={() => clickSort(sortName.message)}
+                tabIndex={0}
               >
                 {sortName.name}
               </li>
             ))}
           </ul>
 
-          <Link to="/create">글쓰기</Link>
+          <Link to="/create" className="font-bold">
+            글쓰기
+          </Link>
         </div>
       ) : (
         ""

--- a/src/components/modal/EnterChatRoom.tsx
+++ b/src/components/modal/EnterChatRoom.tsx
@@ -41,10 +41,14 @@ const EnterChatRoom = ({
             <Link
               to={`/posts/${data ? data.postId : null}`}
               className="btn bg-white mr-4"
+              onClick={closeModal}
             >
               투표글 보러가기
             </Link>
-            <button className="btn bg-black-primary text-white hover:bg-black">
+            <button
+              className="btn bg-black-primary text-white hover:bg-black"
+              onClick={closeModal}
+            >
               채팅방 입장하기
             </button>
           </div>

--- a/src/views/ChatListPage.tsx
+++ b/src/views/ChatListPage.tsx
@@ -1,3 +1,4 @@
+import ScrollTopBtn from "../components/common/ScrollTopBtn";
 import PostCardList from "../components/contents/PostCardList";
 import useFetchData from "../hooks/useFetchData";
 
@@ -19,6 +20,7 @@ const ChatListPage = (): JSX.Element => {
       ) : (
         <PostCardList postData={chatData} title="채팅방" sort={false} />
       )}
+      <ScrollTopBtn />
     </>
   );
 };

--- a/src/views/HotListPage.tsx
+++ b/src/views/HotListPage.tsx
@@ -1,5 +1,6 @@
 import useFetchData from "../hooks/useFetchData";
 import PostCardList from "../components/contents/PostCardList";
+import ScrollTopBtn from "../components/common/ScrollTopBtn";
 
 const HotListPage = (): JSX.Element => {
   const {
@@ -19,6 +20,7 @@ const HotListPage = (): JSX.Element => {
       ) : (
         <PostCardList postData={postData} title="HOT 투표글" sort={false} />
       )}
+      <ScrollTopBtn />
     </>
   );
 };

--- a/src/views/PostListPage.tsx
+++ b/src/views/PostListPage.tsx
@@ -1,5 +1,6 @@
 import useFetchData from "../hooks/useFetchData";
 import PostCardList from "../components/contents/PostCardList";
+import ScrollTopBtn from "../components/common/ScrollTopBtn";
 
 const PostListPage = (): JSX.Element => {
   const {
@@ -19,6 +20,7 @@ const PostListPage = (): JSX.Element => {
       ) : (
         <PostCardList postData={postData} title="투표글" sort={true} />
       )}
+      <ScrollTopBtn />
     </>
   );
 };

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
## PR Type
- [x] Feat: 새로운 기능 구현
- [x] Fix: 버그 수정
- [ ] Docs: 문서 추가 및 수정
- [ ] Style: 코드 포맷 변경
- [x] Design: css 및 UI 관련 변경
- [x] Refactor: 코드 리팩토링
- [ ] Rename: 폴더/파일 이름 및 위치 변경
- [ ] Test: 테스트 관련
- [ ] Deploy: 배포 관련
- [x] Chore: 빌드, 환경 설정 등 기타 작업
- [ ] Add: 기능 구현 외 추가 사항

## Abstracts
* 스크롤 이동 시 헤더 상단에 고정되게 하고 스크롤 탑 이동 버튼 구현했습니다.
* 채팅방 입장 모달창 오류 수정하고 및 탭 포커스 안 되는 부분들 가능하도록 수정했습니다!

## Description
- 채팅방 입장 모달창에서 게시글 이동 버튼 클릭 후에는 스크롤 잠금 해지되도록 수정
- 스크롤 탑 이동 버튼 구현 및 투표글, hot글, 채팅방리스트 페이지에 추가
- 스크롤 이동 시 헤더 상단에 고정
- 메인 채팅방, 투표글 정렬 버튼 탭으로 이동 시 포커스 되도록 수정
- 모바일 크기일 때 메인 섹션 상단 패딩 조절
- 글쓰기 버튼 볼드처리

## Discussion
- 채팅방 입장 버튼 클릭 시 임시로 모달창 닫히고 스크롤 잠금 풀리도록 수정해 놨습니당

---