### PR TITLE
알림 mock 데이터 생성, 알림메시지 모달창 팝업 구현 및 파일명 수정, 메인 채팅 컴포넌트 파일 위치 이동

### DIFF
--- a/src/components/NotificationCard.tsx
+++ b/src/components/NotificationCard.tsx
@@ -3,7 +3,7 @@ import useFetchData from "../hooks/useFetchData";
 import EnterChatRoom from "./modal/EnterChatRoom";
 import { Notification } from "../mocks/mockType";
 
-const NotificationMessage = (): JSX.Element => {
+const NotificationCard = (): JSX.Element => {
   const [showModal, setShowModal] = useState(false);
   const [clickedData, setClickedData] = useState<number | null>(null);
 
@@ -68,4 +68,4 @@ const NotificationMessage = (): JSX.Element => {
   );
 };
 
-export default NotificationMessage;
+export default NotificationCard;

--- a/src/components/NotificationMessage.tsx
+++ b/src/components/NotificationMessage.tsx
@@ -1,42 +1,70 @@
-const NotificationMessage = () => {
-  return (
-    <div>
-      <div className="flex justify-between pt-8 mb-4">
-        <div>1분 전</div>
-        <div>
-          <button>삭제</button>
-        </div>
-      </div>
-      <div
-        tabIndex={0}
-        className="flex flex-col md:flex-row items-center w-full min-h-[96px] p-5 mb-8 bg-white rounded-2xl shadow-md"
-      >
-        <span className="text-lg font-semibold mr-3">
-          깻잎 논쟁에 대해 어떻게 생각하시나요?
-        </span>
-        <span className="text-sm mt-1.5 md:mt-0">
-          투표글의 채팅방이 개설되었어요.
-        </span>
-      </div>
+import { useState } from "react";
+import useFetchData from "../hooks/useFetchData";
+import EnterChatRoom from "./modal/EnterChatRoom";
+import { Notification } from "../mocks/mockType";
 
-      <div className="flex justify-between pt-8 mb-4">
-        <div>2023.08.19</div>
-        <div>
-          <button>삭제</button>
-        </div>
-      </div>
-      <div
-        tabIndex={0}
-        className="opacity-50 flex flex-col md:flex-row items-center w-full min-h-[96px] p-5 mb-8 bg-white rounded-2xl shadow-md"
-      >
-        <span className="text-lg font-semibold mr-3">
-          깻잎 논쟁에 대해 어떻게 생각하시나요?
-        </span>
-        <span className="text-sm mt-1.5 md:mt-0">
-          투표글의 채팅방이 개설되었어요.
-        </span>
-      </div>
-    </div>
+const NotificationMessage = (): JSX.Element => {
+  const [showModal, setShowModal] = useState(false);
+  const [clickedData, setClickedData] = useState<number | null>(null);
+
+  const {
+    isLoading,
+    data: notificationData,
+    isError,
+  } = useFetchData("/notificationData", ["notificationData"]);
+
+  const openModal = (data: Notification) => {
+    setShowModal(true);
+    setClickedData(data.postId);
+    document.body.style.overflow = "hidden";
+  };
+
+  const closeModal = () => {
+    setShowModal(false);
+    setClickedData(null);
+    document.body.style.overflow = "auto";
+  };
+
+  if (isError) {
+    console.log("데이터 불러오기 실패");
+  }
+
+  return (
+    <>
+      {isLoading ? (
+        "Loading..."
+      ) : (
+        <>
+          {notificationData.map((data: Notification) => (
+            <div key={data.notificationId}>
+              <div className="flex justify-between pt-8 mb-4">
+                <div>{data.createdDate}</div>
+                <div>
+                  <button>삭제</button>
+                </div>
+              </div>
+              <div
+                tabIndex={0}
+                onClick={() => openModal(data)}
+                className={`flex flex-col md:flex-row items-center w-full min-h-[96px] p-5 mb-8 bg-white rounded-2xl shadow-md cursor-pointer text-center ${
+                  data.checked ? "opacity-50" : ""
+                }`}
+              >
+                <span className="text-lg font-semibold mr-3">
+                  "{data.postTitle}"
+                </span>
+                <span className="text-sm mt-1.5 md:mt-0">
+                  투표글의 채팅방이 개설되었어요.
+                </span>
+              </div>
+            </div>
+          ))}
+        </>
+      )}
+      {showModal ? (
+        <EnterChatRoom postId={clickedData} closeModal={closeModal} />
+      ) : null}
+    </>
   );
 };
 

--- a/src/components/contents/MainChattingList.tsx
+++ b/src/components/contents/MainChattingList.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
-import useFetchData from "../hooks/useFetchData";
-import ChatUserBadge from "./common/ChatUserBadge";
-import EnterChatRoom from "./modal/EnterChatRoom";
-import { Post } from "../mocks/mockType";
+import useFetchData from "../../hooks/useFetchData";
+import ChatUserBadge from "../common/ChatUserBadge";
+import EnterChatRoom from "../modal/EnterChatRoom";
+import { Post } from "../../mocks/mockType";
 
 const MainChattingList = (): JSX.Element => {
   const [showModal, setShowModal] = useState(false);

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -2,6 +2,7 @@ import { rest } from "msw";
 import { postListData } from "./mockDatas/postListData";
 import { commentListData } from "./mockDatas/commentListData";
 import { activeChatListData } from "./mockDatas/activeChatListData";
+import { notificationData } from "./mockDatas/notificationData";
 import { PostListData, CommentListData } from "./mockType";
 
 export const handlers = [
@@ -32,5 +33,10 @@ export const handlers = [
   // activeChatListData 조회
   rest.get("/activeChatListData", (_req, res, ctx) => {
     return res(ctx.status(200), ctx.json(activeChatListData));
+  }),
+
+  // NotificationData 조회
+  rest.get("/notificationData", (_req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(notificationData));
   }),
 ];

--- a/src/mocks/mockDatas/notificationData.ts
+++ b/src/mocks/mockDatas/notificationData.ts
@@ -1,0 +1,20 @@
+import { NotificationData } from "../mockType";
+
+export const notificationData: NotificationData = {
+  content: [
+    {
+      notificationId: 2,
+      checked: false,
+      createdDate: "1분 전",
+      postId: 2,
+      postTitle: "소개팅 장소 어디가 좋을까요?",
+    },
+    {
+      notificationId: 1,
+      checked: true,
+      createdDate: "2023.08.11",
+      postId: 5,
+      postTitle: "요즘 날씨에 어울리는 옷은?",
+    },
+  ],
+};

--- a/src/mocks/mockType.ts
+++ b/src/mocks/mockType.ts
@@ -29,6 +29,14 @@ type Comment = {
   deletedDate: string | null;
 };
 
+export type Notification = {
+  notificationId: number;
+  checked: boolean;
+  createdDate: string;
+  postId: number;
+  postTitle: string;
+};
+
 type Pageable = {
   sort: { sorted: boolean; unsorted: boolean; empty: boolean };
   pageNumber: number;
@@ -66,4 +74,8 @@ export type CommentListData = {
   numberOfElements: number;
   first: boolean;
   empty: boolean;
+};
+
+export type NotificationData = {
+  content: Notification[];
 };

--- a/src/views/MainPage.tsx
+++ b/src/views/MainPage.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import useFetchData from "../hooks/useFetchData";
-import MainChattingList from "../components/MainChattingList";
+import MainChattingList from "../components/contents/MainChattingList";
 import PostCardList from "../components/contents/PostCardList";
 
 const MainPage = (): JSX.Element => {

--- a/src/views/NotificationPage.tsx
+++ b/src/views/NotificationPage.tsx
@@ -1,4 +1,4 @@
-import NotificationMessage from "../components/NotificationMessage";
+import NotificationCard from "../components/NotificationCard";
 
 const NotificationPage = (): JSX.Element => {
   return (
@@ -7,7 +7,7 @@ const NotificationPage = (): JSX.Element => {
         <h1 className="text-2xl font-semibold">채팅방 개설 알림</h1>
         <button>전체 삭제</button>
       </div>
-      <NotificationMessage />
+      <NotificationCard />
     </>
   );
 };


### PR DESCRIPTION
## PR Type
- [x] Feat: 새로운 기능 구현
- [ ] Fix: 버그 수정
- [ ] Docs: 문서 추가 및 수정
- [ ] Style: 코드 포맷 변경
- [ ] Design: css 및 UI 관련 변경
- [ ] Refactor: 코드 리팩토링
- [x] Rename: 폴더/파일 이름 및 위치 변경
- [ ] Test: 테스트 관련
- [ ] Deploy: 배포 관련
- [ ] Chore: 빌드, 환경 설정 등 기타 작업
- [ ] Add: 기능 구현 외 추가 사항

## Abstracts
* 알림 mock 데이터 생성, 알림페이지 모달창 팝업 구현 및  파일명 수정하고 메인 채팅 컴포넌트 파일 위치 이동했습니다!

## Description
- 알림 데이터 생성 및 타입 설정
- 알림 데이터 handler 조회 함수 작성
- 알림메시지 클릭 시 채팅방 입장 모달창 팝업
- 알림메시지 데이터의 checked가 true인 경우 opacity-50 적용
- NotificationMessage.tsx -> NotificationCard.tsx 파일명 변경
- MainChattingList.tsx 파일 위치 components/contents 폴더 안으로 이동

## Discussion
* 알림 mock 데이터에 pagable 관련 데이터 작성 필요
---
Close #48 