### PR TITLE
Not found Page, Error Page 페이지 분리

### DIFF
--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -9,12 +9,12 @@ import CreatePostPage from "../views/CreatePostPage";
 import MemberPage from "../views/MemberPage";
 import NotificationPage from "../views/NotificationPage";
 import LoginPage from "../views/LoginPage";
-import ErrorPage from "../views/ErrorPage";
+import NotFoundPage from "../views/NotFoundPage";
 
 const Router = (): JSX.Element => {
   return (
     <Routes>
-      <Route path="*" element={<ErrorPage />} />
+      <Route path="*" element={<NotFoundPage />} />
       <Route path="/" element={<MainPage />} />
       <Route path="/login" element={<LoginPage />} />
       <Route path="/posts" element={<PostListPage />} />

--- a/src/views/NotFoundPage.tsx
+++ b/src/views/NotFoundPage.tsx
@@ -1,22 +1,20 @@
-const ErrorPage = () => {
-  const onReloadClick = () => {
-    location.reload();
-  };
+import { Link } from "react-router-dom";
 
+const NotFoundPage = () => {
   return (
     <div className="flex flex-col items-center justify-center pt-8">
       <div className="text-center mb-12">
         <p className="text-6xl font-bold mb-2">404</p>
-        <p className="text-xl">앗! 페이지를 로드할 수 없어요.</p>
+        <p className="text-xl">앗! 페이지를 찾을 수 없어요.</p>
       </div>
-      <button
-        onClick={onReloadClick}
+      <Link
+        to="/"
         className="btn bg-black-primary text-white hover:bg-black px-6"
       >
-        새로고침
-      </button>
+        메인으로
+      </Link>
     </div>
   );
 };
 
-export default ErrorPage;
+export default NotFoundPage;

--- a/src/views/NotFoundPage.tsx
+++ b/src/views/NotFoundPage.tsx
@@ -1,0 +1,26 @@
+import { useNavigate } from "react-router-dom";
+
+const NotFoundPage = () => {
+  const navigate = useNavigate();
+  const onClick = () => {
+    navigate("/");
+    location.reload();
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center pt-8">
+      <div className="text-center mb-12">
+        <p className="text-6xl font-bold mb-2">404</p>
+        <p className="text-xl">앗! 페이지를 찾을 수 없어요.</p>
+      </div>
+      <button
+        onClick={onClick}
+        className="btn bg-black-primary text-white hover:bg-black px-6"
+      >
+        메인으로
+      </button>
+    </div>
+  );
+};
+
+export default NotFoundPage;


### PR DESCRIPTION
## PR Type
- [x] Feat: 새로운 기능 구현
- [ ] Fix: 버그 수정
- [ ] Docs: 문서 추가 및 수정
- [ ] Style: 코드 포맷 변경
- [ ] Design: css 및 UI 관련 변경
- [ ] Refactor: 코드 리팩토링
- [ ] Rename: 폴더/파일 이름 및 위치 변경
- [ ] Test: 테스트 관련
- [ ] Deploy: 배포 관련
- [ ] Chore: 빌드, 환경 설정 등 기타 작업
- [ ] Add: 기능 구현 외 추가 사항

## Abstracts
* 없는 경로인 경우와 있는 페이지에서 오류가 난 경우의 컴포넌트를 분리하고 각각 라우터 path와 ErrorBoundary로 해당 페이지로 이동하게 구현했습니다.

## Description
- 없는 경로로 접근했을 경우 라우터로 Not Found 페이지 처리, 메인으로 버튼 
- 있는 페이지에서 오류 난 경우 ErrorBoundary로 에러페이지 처리, 새로고침 버튼
- not found 페이지에서 메인으로 버튼 클릭 시 메인으로 이동 후 새로고침을 해서 페이지를 새로 로드하도록 수정


## Discussion
* not found 페이지에서 메인으로 버튼이 안 되는 경우가 있어서 메인으로 이동 후 새로고침 되도록 작성했습니다! 메인으로 버튼을 눌렀을 때 메인 페이지가 로드 될 때도 있고 안 될 때도 있는데(경로는 /로 바뀌는데 페이지 로드가 안 됩니다), msw 데이터 연결이 끊겨서 오류가 난 경우에는 새로고침을 해서 새로 로드를 해야 데이터가 다시 연결되는 것 같습니당.. 

---