### PR TITLE
채팅방 소켓 연결 오류 해결, 채팅 메시지에 닉네임+시간 추가, 채팅방 페이지에서 헤더+푸터 제거 및 채팅방 디자인 수정 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,31 +1,14 @@
 import { BrowserRouter } from "react-router-dom";
 import { RecoilRoot } from "recoil";
-import { ErrorBoundary } from "react-error-boundary";
-import Header from "./components/common/Header";
-import Footer from "./components/common/Footer";
 import Router from "./router/router";
 import ScrollToTop from "./components/ScrollToTop";
-import ErrorPage from "./views/ErrorPage";
-import { Suspense } from "react";
 
 function App() {
   return (
     <BrowserRouter>
       <RecoilRoot>
         <ScrollToTop />
-        <Header />
-        <main className="main pt-12 md:pt-20 pb-24 px-4 md:px-12 mx-auto xl:container">
-          <ErrorBoundary FallbackComponent={ErrorPage}>
-            <Suspense
-              fallback={
-                <span className="flex mx-auto loading loading-spinner loading-md text-gray/[0.2]"></span>
-              }
-            >
               <Router />
-            </Suspense>
-          </ErrorBoundary>
-        </main>
-        <Footer />
       </RecoilRoot>
     </BrowserRouter>
   );

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -12,7 +12,7 @@ const Header = ({
   const navigate = useNavigate();
   return (
     <>
-      <div className="flex items-center justify-between py-4 px-2 bg-white border-b border-gray/[0.2]">
+      <div className="flex items-center justify-between h-16 px-2 bg-white border-b border-gray/[0.2]">
         <button
           onClick={() => {
             exit();

--- a/src/components/chat/ChatList.tsx
+++ b/src/components/chat/ChatList.tsx
@@ -1,10 +1,26 @@
-const ChatList = ({ chatList }: { chatList: string[] }): JSX.Element => {
+const ChatList = ({
+  chatList,
+}: {
+  chatList: { sender: string | null; chat: string | null }[];
+}): JSX.Element => {
   return (
-    <>
-      {chatList.map((textList, index) => (
-        <p key={index}>{textList}</p>
+    <div className="pt-20 px-2">
+      {chatList.map((chat, index) => (
+        <>
+          {chat.sender !== null && (
+            <div key={index}>
+              <div className="flex flex-col p-1 chat chat-start mb-1">
+                <div className="chat-header mb-1">{chat.sender}</div>
+                <div className="flex items-end">
+                  <div className="chat-bubble bg-blue-200">{chat.chat}</div>
+                  <time className="text-xs opacity-50 ml-1">00:00</time>
+                </div>
+              </div>
+            </div>
+          )}
+        </>
       ))}
-    </>
+    </div>
   );
 };
 

--- a/src/components/chat/ChatRoom.tsx
+++ b/src/components/chat/ChatRoom.tsx
@@ -19,7 +19,7 @@ const Chat = (): JSX.Element => {
   const userData = useRecoilValue(userInfoState);
 
   const [client, setClient] = useState<StompJs.Client | null>(null);
-  const [chatList, setChatList] = useState<string[]>([]);
+  const [chatList, setChatList] = useState([{ sender: null, chat: null }]);
   const [message, setMessage] = useState<string>("");
 
   const param = useParams();
@@ -60,10 +60,11 @@ const Chat = (): JSX.Element => {
   };
 
   // 주고 받는 메시지 list에 추가
-  const subCallback = (message: StompJs.IMessage) => {
-    if (message.body) {
-      const msg = JSON.parse(message.body);
-      setChatList((chats) => [...chats, msg]);
+  const subCallback = (res: StompJs.IMessage) => {
+    if (res.body) {
+      const { sender, message } = JSON.parse(res.body);
+      setChatList((prev) => [...prev, { sender: sender, chat: message }]);
+      console.log(`sender: ${sender}`);
     }
   };
 

--- a/src/components/chat/ChatRoom.tsx
+++ b/src/components/chat/ChatRoom.tsx
@@ -115,13 +115,13 @@ const Chat = (): JSX.Element => {
 
   return (
     <>
-      <section className="relative h-full w-[425px] m-auto border border-black">
+      <section className="relative h-screen min-h-[500px] w-full md:w-[425px] m-auto border border-black">
         <ChatHeader roomId={roomId} exit={disConnect} />
         <InfoBar />
-        <div className="min-h-[350px] bg-color-bg">
-          <ChatList chatList={chatList} />
-        </div>
-        <div>
+        <div className="flex flex-col justify-between h-[calc(100%-64px)]">
+          <div className="overflow-y-scroll bg-color-bg">
+            <ChatList chatList={chatList} />
+          </div>
           <MessageForm
             message={message}
             submitMsg={onSubmit}

--- a/src/components/chat/ChatRoom.tsx
+++ b/src/components/chat/ChatRoom.tsx
@@ -45,10 +45,11 @@ const Chat = (): JSX.Element => {
         heartbeatOutgoing: 4000,
       });
 
-      // 연결이 되면 room 입장
       client.onConnect = () => {
         console.log("연결 성공!");
-        client.subscribe(`/sub/chat/room/${roomId}`, subCallback);
+        client.subscribe(`/sub/chat/room/${roomId}`, subCallback, {
+          token: token,
+        });
       };
 
       client.activate();

--- a/src/components/chat/InfoBar.tsx
+++ b/src/components/chat/InfoBar.tsx
@@ -3,14 +3,14 @@
 const InfoBar = (): JSX.Element => {
   return (
     <>
-      <div className="absolute w-full p-1">
+      <div className="absolute w-full p-1 z-20">
         <div tabIndex={0} className="collapse bg-base-200 shadow-sm">
           <input type="checkbox" />
           <div className="collapse-title bg-white text-base">투표글 제목</div>
           <div className="collapse-content bg-white">
-            <p>투표글 제목</p>
-            <p>A옵션</p>
-            <p>B옵션</p>
+            <p className="mb-2">투표글 제목</p>
+            <p className="py-1">A옵션</p>
+            <p className="py-1">B옵션</p>
           </div>
         </div>
       </div>

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -1,4 +1,6 @@
-import { Routes, Route } from "react-router-dom";
+import { Suspense } from "react";
+import { Routes, Route, useLocation } from "react-router-dom";
+import { ErrorBoundary } from "react-error-boundary";
 import MainPage from "../views/MainPage";
 import PostListPage from "../views/PostListPage";
 import HotListPage from "../views/HotListPage";
@@ -12,8 +14,43 @@ import LoginPage from "../views/LoginPage";
 import NotFoundPage from "../views/NotFoundPage";
 import LoginRedirectPage from "../views/LoginCallbackPage";
 import ChatRoom from "../components/chat/ChatRoom";
+import Header from "../components/common/Header";
+import ErrorPage from "../views/ErrorPage";
+import Footer from "../components/common/Footer";
 
 const Router = (): JSX.Element => {
+  const location = useLocation();
+  const chatPage = ["/chat/"];
+  const hideHeaderFooter = chatPage.some((path) =>
+    location.pathname.startsWith(path)
+  );
+
+  return (
+    <>
+      {!hideHeaderFooter && <Header />}
+      <main
+        className={`${
+          !hideHeaderFooter
+            ? "main pt-12 md:pt-20 pb-24 px-4 md:px-12 mx-auto xl:container"
+            : ""
+        }`}
+      >
+        <ErrorBoundary FallbackComponent={ErrorPage}>
+          <Suspense
+            fallback={
+              <span className="flex mx-auto loading loading-spinner loading-md text-gray/[0.2]"></span>
+            }
+          >
+            <AllRoutes />
+          </Suspense>
+        </ErrorBoundary>
+      </main>
+      {!hideHeaderFooter && <Footer />}
+    </>
+  );
+};
+
+const AllRoutes = () => {
   return (
     <Routes>
       <Route path="*" element={<NotFoundPage />} />


### PR DESCRIPTION
## PR Type
- [ ] Feat: 새로운 기능 구현
- [x] Fix: 버그 수정
- [ ] Docs: 문서 추가 및 수정
- [ ] Style: 코드 포맷 변경
- [x] Design: css 및 UI 관련 변경
- [x] Refactor: 코드 리팩토링
- [ ] Rename: 폴더/파일 이름 및 위치 변경
- [ ] Test: 테스트 관련
- [ ] Deploy: 배포 관련
- [ ] Chore: 빌드, 환경 설정 등 기타 작업
- [ ] Add: 기능 구현 외 추가 사항

## Abstracts
* 채팅방 소켓 연결 오류 해결, 채팅 메시지에 닉네임+시간 추가, 채팅방 페이지에서 헤더+푸터 제거 및 채팅방 디자인 수정 

## Description
- 채팅방 구독 시 token 전달, 재연결 반복되는 오류 해결
- 채팅 리스트로 메시지+닉네임+시간 렌더링
- 채팅 말풍선 디자인 추가
- 모바일 사이즈에서 가로 사이즈 화면에 꽉 차게 구현
- 세로 사이즈 화면에 꽉 차게 구현, 최소 사이즈 지정
- path로 채팅방 페이지인지 구분해서 헤더, 푸터 조건부 렌더링

![image](https://github.com/winnow-2023/best-choice-fe/assets/123265266/0da9dbfc-3645-47a0-be28-000a090caab9)

## Discussion
* 채팅방 부분은 아직 시간, 말풍선 방향 등등 수정이 좀 필요합니당 ,,!

---

