### PR TITLE
UseInfiniteQuery사용 무한스크롤 구현, 채팅방 입장 버튼 디자인 조건부 렌더링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "react-dom": "^18.2.0",
         "react-error-boundary": "^4.0.11",
         "react-icons": "^4.10.1",
-        "react-infinite-scroller": "^1.2.6",
         "react-js-pagination": "^3.0.3",
         "react-query": "^3.39.3",
         "react-quill": "^2.0.0",
@@ -6987,17 +6986,6 @@
       "integrity": "sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==",
       "peerDependencies": {
         "react": "*"
-      }
-    },
-    "node_modules/react-infinite-scroller": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/react-infinite-scroller/-/react-infinite-scroller-1.2.6.tgz",
-      "integrity": "sha512-mGdMyOD00YArJ1S1F3TVU9y4fGSfVVl6p5gh/Vt4u99CJOptfVu/q5V/Wlle72TMgYlBwIhbxK5wF0C/R33PXQ==",
-      "dependencies": {
-        "prop-types": "^15.5.8"
-      },
-      "peerDependencies": {
-        "react": "^0.14.9 || ^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-is": {

--- a/src/components/common/button/EnterChatRoomBtn.tsx
+++ b/src/components/common/button/EnterChatRoomBtn.tsx
@@ -4,9 +4,11 @@ import { useNavigate } from "react-router";
 const EnterChatRoomBtn = ({
   postId,
   token,
+  isModal,
 }: {
   postId: string;
   token: string;
+  isModal: boolean;
 }) => {
   const navigate = useNavigate();
 
@@ -33,7 +35,11 @@ const EnterChatRoomBtn = ({
     <>
       <button
         onClick={handleEnterChatRoom}
-        className="btn border-blue-300 bg-blue-200 text-black hover:bg-blue-300 hover:border-blue-300"
+        className={`${
+          isModal
+            ? "btn bg-black-primary text-white hover:bg-black"
+            : "btn border-blue-300 bg-blue-200 text-black hover:bg-blue-300 hover:border-blue-300"
+        }`}
       >
         채팅방 입장하기
       </button>

--- a/src/components/contents/PostDetail.tsx
+++ b/src/components/contents/PostDetail.tsx
@@ -312,7 +312,11 @@ const PostDetail = ({ postId }: { postId: string }): JSX.Element => {
                 <CreateChatRoomBtn postId={postData.postId} token={token} />
               )}
               {isChatActive && (
-                <EnterChatRoomBtn postId={postData.postId} token={token} />
+                <EnterChatRoomBtn
+                  postId={postData.postId}
+                  token={token}
+                  isModal={false}
+                />
               )}
             </div>
           </div>

--- a/src/components/modal/EnterChatRoom.tsx
+++ b/src/components/modal/EnterChatRoom.tsx
@@ -85,7 +85,11 @@ const EnterChatRoom = ({
             >
               투표글 보러가기
             </Link>
-            <EnterChatRoomBtn postId={String(postId)} token={token} />
+            <EnterChatRoomBtn
+              postId={viewData.postId}
+              token={token}
+              isModal={true}
+            />
           </div>
         </div>
       </div>

--- a/src/hooks/useInfinitePosts.tsx
+++ b/src/hooks/useInfinitePosts.tsx
@@ -1,0 +1,50 @@
+import axios from "axios";
+import { useInfiniteQuery } from "react-query";
+
+const getPosts = async ({
+  token,
+  currentSort,
+  pageParam = 0,
+}: {
+  token: string;
+  currentSort: string;
+  pageParam: number;
+}) => {
+  const apiUrl = token
+    ? `/api/api/posts/my?sort=${currentSort}&page=${pageParam}`
+    : `/api/posts?sort=${currentSort}&page=${pageParam}`;
+  const auth = token || "";
+
+  try {
+    const response = await axios({
+      method: "get",
+      url: apiUrl,
+      headers: { Authorization: `Bearer ${auth}` },
+    });
+
+    return response.data;
+  } catch (error) {
+    throw new Error("데이터를 불러오는 중 오류 발생");
+  }
+};
+
+export function useInfinitePosts({
+  token,
+  currentSort,
+}: {
+  token: string;
+  currentSort: string;
+}) {
+  return useInfiniteQuery(
+    `${currentSort}posts`,
+    ({ pageParam = 0 }) => getPosts({ token, currentSort, pageParam }),
+    {
+      getNextPageParam: (lastPage, viewPages) => {
+        if (lastPage.content.length < 10) {
+          return null;
+        }
+        return viewPages.length;
+      },
+    }
+  );
+}

--- a/src/views/PostListPage.tsx
+++ b/src/views/PostListPage.tsx
@@ -47,7 +47,7 @@ const PostListPage = (): JSX.Element => {
         </div>
         <ErrorBoundary FallbackComponent={ErrorMessage}>
           <Suspense fallback={<LoadPostCard limit={10} />}>
-            <PostCardList limit={null} sort={postSort} token={null} />
+            <PostCardList limit={null} sort={postSort} token={""} />
           </Suspense>
         </ErrorBoundary>
       </>


### PR DESCRIPTION
## PR Type
- [x] Feat: 새로운 기능 구현
- [ ] Fix: 버그 수정
- [ ] Docs: 문서 추가 및 수정
- [ ] Style: 코드 포맷 변경
- [ ] Design: css 및 UI 관련 변경
- [x] Refactor: 코드 리팩토링
- [ ] Rename: 폴더/파일 이름 및 위치 변경
- [ ] Test: 테스트 관련
- [ ] Deploy: 배포 관련
- [ ] Chore: 빌드, 환경 설정 등 기타 작업
- [ ] Add: 기능 구현 외 추가 사항

## Abstracts
* UseInfiniteQuery사용 무한스크롤 구현, 채팅방 입장 버튼 디자인 조건부 렌더링

## Description
- useInfiniteQuery, intersection observer 사용 
- useInfinitePosts 컴포넌트 생성
- 투표글 리스트, 회원페이지 투표글 무한스크롤 구현
- props로 받은 상세페이지/채팅방 입장 모달 boolean 값에 따라 채팅방 입장 버튼 스타일 조건부 렌더링

![무한스크롤](https://github.com/winnow-2023/best-choice-fe/assets/123265266/34b05981-7108-4d49-99f0-29a9795466a8)

## Discussion
* 무한스크롤 정렬 바꾸면 0페이지 데이터만 렌더링 하는 기능, 데이터 없을 때 없다는 메시지 렌더링 하는 기능 수정이 필요합니당..!

---
Close #89 
