### PR TITLE
무한스크롤 데이터 없는 경우에 대한 조건문 코드 수정, 한 페이지당 데이터 개수 변수로 분리, 채팅방 리스트 카드 날짜 형식 수정

### DIFF
--- a/src/components/contents/ChatCardList.tsx
+++ b/src/components/contents/ChatCardList.tsx
@@ -8,6 +8,7 @@ import ChatUserBadge from "../common/ChatUserBadge";
 import { AiOutlineComment } from "react-icons/ai";
 import { RiThumbUpLine } from "react-icons/ri";
 import NoDataMessage from "../common/NoDataMessage";
+import { TimeDiff } from "../common/TimeDiff";
 
 const ChatCardList = () => {
   const token = useRecoilValue<string>(accessTokenState);
@@ -80,7 +81,7 @@ const ChatCardList = () => {
               </div>
               <div className="flex text-sm text-gray">
                 <p className="mr-3.5">{chat.nickname}</p>
-                <p>{chat.createdDate.split(" ")[0]}</p>
+                <p>{TimeDiff(chat.createdDate)}</p>
               </div>
             </div>
           </div>

--- a/src/components/contents/PostCardList.tsx
+++ b/src/components/contents/PostCardList.tsx
@@ -53,7 +53,7 @@ const PostCardList = ({
     }
   }, [isBottom, hasNextPage, fetchNextPage]);
 
-  if (!data || data.pages.length <= 0) {
+  if (!data || data.pages[0].content.length <= 0) {
     return <NoDataMessage message="투표글 데이터가 없어요" />;
   }
 

--- a/src/hooks/useInfinitePosts.tsx
+++ b/src/hooks/useInfinitePosts.tsx
@@ -28,23 +28,25 @@ const getPosts = async ({
   }
 };
 
-export function useInfinitePosts({
+export const useInfinitePosts = ({
   token,
   currentSort,
 }: {
   token: string;
   currentSort: string;
-}) {
+}) => {
+  const CONTENTS_LENGTH = 10;
+
   return useInfiniteQuery(
     `${currentSort}posts`,
     ({ pageParam = 0 }) => getPosts({ token, currentSort, pageParam }),
     {
       getNextPageParam: (lastPage, viewPages) => {
-        if (lastPage.content.length < 10) {
+        if (lastPage.content.length < CONTENTS_LENGTH) {
           return null;
         }
         return viewPages.length;
       },
     }
   );
-}
+};


### PR DESCRIPTION
## PR Type
- [ ] Feat: 새로운 기능 구현
- [x] Fix: 버그 수정
- [ ] Docs: 문서 추가 및 수정
- [ ] Style: 코드 포맷 변경
- [ ] Design: css 및 UI 관련 변경
- [x] Refactor: 코드 리팩토링
- [ ] Rename: 폴더/파일 이름 및 위치 변경
- [ ] Test: 테스트 관련
- [ ] Deploy: 배포 관련
- [ ] Chore: 빌드, 환경 설정 등 기타 작업
- [ ] Add: 기능 구현 외 추가 사항

## Abstracts
* 무한스크롤 데이터 없는 경우에 대한 조건문 코드 수정, 한 페이지당 데이터 개수 변수로 분리, 채팅방 리스트 카드 날짜 형식 수정

## Description
- 데이터 없으면 NoDataMessage 컴포넌트 렌더링 되도록 조건문 코드 수정
- 한 페이지당 데이터 개수 변수로 분리
- useInfinitePosts 화살표 함수로 수정
- 채팅방 리스트 페이지 카드의 날짜를 채팅방 열린 시간에 따라 n분 전, n시간 전, YYYY-MM-DD 형식으로 수정

## Discussion
* 
---
