### PR TITLE
BasicModal을 ConfrimModal과 AlertModal로 분리, 로그아웃 후 댓글 삭제 버튼 뜨는 오류 수정

### DIFF
--- a/src/components/comment/CommentList.tsx
+++ b/src/components/comment/CommentList.tsx
@@ -8,7 +8,7 @@ import {
   accessTokenState,
 } from "../../states/recoil";
 import { Comment } from "../../mocks/mockType";
-import BasicModal from "../modal/BasicModal";
+import ConfirmModal from "../modal/ConfirmModal";
 import NoDataMessage from "../common/NoDataMessage";
 import moment from "moment";
 import CommentLikeBtn from "../common/button/CommentLikeBtn";
@@ -133,7 +133,7 @@ const CommentList = ({ sort, postId }: { sort: string; postId: string }) => {
         </div>
       )}
       {showModal && (
-        <BasicModal
+        <ConfirmModal
           message="댓글을 삭제할까요?"
           closeModal={closeModal}
           confirm={deleteComment}

--- a/src/components/comment/CommentList.tsx
+++ b/src/components/comment/CommentList.tsx
@@ -105,7 +105,7 @@ const CommentList = ({ sort, postId }: { sort: string; postId: string }) => {
                     liked={commentData.liked ? true : false}
                   />
                 </ul>
-                {userData.memberId === commentData.member.memberId && (
+                {token && userData.memberId === commentData.member.memberId && (
                   <button
                     className="text-red-dark text-sm"
                     onClick={() => openModal(commentData.commentId)}

--- a/src/components/common/button/CommentLikeBtn.tsx
+++ b/src/components/common/button/CommentLikeBtn.tsx
@@ -4,7 +4,7 @@ import { RiThumbUpLine, RiThumbUpFill } from "react-icons/ri";
 import { useRecoilValue } from "recoil";
 import { useMutation, useQueryClient } from "react-query";
 import { accessTokenState } from "../../../states/recoil";
-import BasicModal from "../../modal/BasicModal";
+import AlertModal from "../../modal/AlertModal";
 
 const CommentLikeBtn = ({
   commentId,
@@ -123,11 +123,7 @@ const CommentLikeBtn = ({
         <span>{likeInfo.totalLikeCount}</span>
       </div>
       {showModal && (
-        <BasicModal
-          message="로그인 후 이용해 주세요"
-          closeModal={closeModal}
-          confirm={closeModal}
-        />
+        <AlertModal message="로그인 후 이용해 주세요" closeModal={closeModal} />
       )}
     </>
   );

--- a/src/components/common/button/EnterChatRoomBtn.tsx
+++ b/src/components/common/button/EnterChatRoomBtn.tsx
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { useState } from "react";
 import { useNavigate } from "react-router";
-import BasicModal from "../../modal/BasicModal";
+import AlertModal from "../../modal/AlertModal";
 
 const maxUserCount = 10;
 
@@ -74,11 +74,7 @@ const EnterChatRoomBtn = ({
         채팅방 입장하기
       </button>
       {showModal && (
-        <BasicModal
-          message={modalMessage}
-          closeModal={closeModal}
-          confirm={closeModal}
-        />
+        <AlertModal message={modalMessage} closeModal={closeModal} />
       )}
     </>
   );

--- a/src/components/common/button/PostLikeBtn.tsx
+++ b/src/components/common/button/PostLikeBtn.tsx
@@ -4,7 +4,7 @@ import { RiThumbUpLine, RiThumbUpFill } from "react-icons/ri";
 import { useRecoilValue } from "recoil";
 import { useMutation, useQueryClient } from "react-query";
 import { accessTokenState } from "../../../states/recoil";
-import BasicModal from "../../modal/BasicModal";
+import AlertModal from "../../modal/AlertModal";
 
 const PostLikeBtn = ({
   postId,
@@ -122,11 +122,7 @@ const PostLikeBtn = ({
         <span className="font-semibold">{likeInfo.totalLikeCount}</span>
       </div>
       {showModal && (
-        <BasicModal
-          message="로그인 후 이용해 주세요"
-          closeModal={closeModal}
-          confirm={closeModal}
-        />
+        <AlertModal message="로그인 후 이용해 주세요" closeModal={closeModal} />
       )}
     </>
   );

--- a/src/components/contents/NotificationCard.tsx
+++ b/src/components/contents/NotificationCard.tsx
@@ -6,7 +6,7 @@ import { Notification } from "../../mocks/mockType";
 import NoDataMessage from "../common/NoDataMessage";
 import { useRecoilValue } from "recoil";
 import { accessTokenState } from "../../states/recoil";
-import BasicModal from "../modal/BasicModal";
+import ConfirmModal from "../modal/ConfirmModal";
 import { TimeDiff } from "../common/TimeDiff";
 
 const NotificationCard = (): JSX.Element => {
@@ -116,7 +116,7 @@ const NotificationCard = (): JSX.Element => {
         />
       )}
       {showDeleteAllModal && (
-        <BasicModal
+        <ConfirmModal
           message={"전체 알림을 삭제할까요?"}
           closeModal={() => closeModal(setShowDeleteAllModal)}
           confirm={onDeleteAllNoticeClick}

--- a/src/components/contents/PostDetail.tsx
+++ b/src/components/contents/PostDetail.tsx
@@ -13,7 +13,8 @@ import DOMPurify from "dompurify";
 import parse from "html-react-parser";
 import useFetchData from "../../hooks/useFetchData";
 import VoteGraph from "./VoteGraph";
-import BasicModal from "../modal/BasicModal";
+import AlertModal from "../modal/AlertModal";
+import ConfirmModal from "../modal/ConfirmModal";
 import NoDataMessage from "../common/NoDataMessage";
 import { accessTokenState, userInfoState } from "../../states/recoil";
 import { UserInfoState } from "../../states/recoilType";
@@ -322,30 +323,28 @@ const PostDetail = ({ postId }: { postId: string }): JSX.Element => {
       </div>
       {showReportModal &&
         (postData.reported ? (
-          <BasicModal
+          <AlertModal
             message="이미 신고한 투표글이에요"
             closeModal={() => closeModal(setShowReportModal)}
-            confirm={() => closeModal(setShowReportModal)}
           />
         ) : (
-          <BasicModal
+          <ConfirmModal
             message="해당 투표글을 신고 할까요?"
             closeModal={() => closeModal(setShowReportModal)}
             confirm={reportPost}
           />
         ))}
       {showDeleteModal && (
-        <BasicModal
+        <ConfirmModal
           message="해당 투표글을 삭제 할까요?"
           closeModal={() => closeModal(setShowDeleteModal)}
           confirm={deletePost}
         />
       )}
       {showAlertModal && (
-        <BasicModal
+        <AlertModal
           message="로그인 후 이용해 주세요"
           closeModal={() => closeModal(setShowAlertModal)}
-          confirm={() => closeModal(setShowAlertModal)}
         />
       )}
     </>

--- a/src/components/create/FileInput.tsx
+++ b/src/components/create/FileInput.tsx
@@ -2,7 +2,7 @@ import { ChangeEvent, useState } from "react";
 import { RecoilState, useSetRecoilState } from "recoil";
 import { inputValueState } from "../../states/recoil";
 import { InputValue } from "../../states/recoilType";
-import BasicModal from "../modal/BasicModal";
+import AlertModal from "../modal/AlertModal";
 
 const maxFileCnt = 5;
 const maxFileSize = 1024 * 1024 * 100;
@@ -122,11 +122,7 @@ const FileInput = () => {
         ))}
       </div>
       {showModal ? (
-        <BasicModal
-          message={modalMessage}
-          closeModal={closeModal}
-          confirm={closeModal}
-        />
+        <AlertModal message={modalMessage} closeModal={closeModal} />
       ) : null}
     </>
   );

--- a/src/components/modal/AlertModal.tsx
+++ b/src/components/modal/AlertModal.tsx
@@ -1,0 +1,32 @@
+import { MdOutlineClose } from "react-icons/md";
+
+const AlertModal = ({
+  message,
+  closeModal,
+}: {
+  message: string;
+  closeModal: () => void;
+}) => {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black/[0.8] z-50">
+      <>
+        <div className="flex flex-col min-w-[300px] h-fit rounded-xl bg-white z-20 py-4 px-3 mx-2">
+          <button className="flex justify-end text-2xl" onClick={closeModal}>
+            <MdOutlineClose />
+          </button>
+          <div className="flex flex-col justify-center items-center px-4 py-2 md:px-8">
+            <p className="text-lg">{message}</p>
+            <button
+              className="btn bg-black-primary text-white hover:bg-black mt-12 px-8"
+              onClick={closeModal}
+            >
+              확인
+            </button>
+          </div>
+        </div>
+      </>
+    </div>
+  );
+};
+
+export default AlertModal;

--- a/src/components/modal/ConfirmModal.tsx
+++ b/src/components/modal/ConfirmModal.tsx
@@ -1,6 +1,6 @@
 import { MdOutlineClose } from "react-icons/md";
 
-const BasicModal = ({
+const ConfirmModal = ({
   message,
   closeModal,
   confirm,
@@ -18,12 +18,17 @@ const BasicModal = ({
           </button>
           <div className="flex flex-col justify-center items-center px-4 py-2 md:px-8">
             <p className="text-lg">{message}</p>
-            <button
-              className="btn bg-black-primary text-white hover:bg-black mt-12 px-8"
-              onClick={confirm}
-            >
-              확인
-            </button>
+            <div className="flex gap-4">
+              <button className="btn mt-12 px-8" onClick={closeModal}>
+                취소
+              </button>
+              <button
+                className="btn bg-black-primary text-white hover:bg-black mt-12 px-8"
+                onClick={confirm}
+              >
+                확인
+              </button>
+            </div>
           </div>
         </div>
       </>
@@ -31,4 +36,4 @@ const BasicModal = ({
   );
 };
 
-export default BasicModal;
+export default ConfirmModal;

--- a/src/components/modal/EnterChatRoom.tsx
+++ b/src/components/modal/EnterChatRoom.tsx
@@ -4,7 +4,7 @@ import { accessTokenState } from "../../states/recoil";
 import { MdOutlineClose } from "react-icons/md";
 import useFetchData from "../../hooks/useFetchData";
 import { Post } from "../../mocks/mockType";
-import BasicModal from "./BasicModal";
+import AlertModal from "./AlertModal";
 import EnterChatRoomBtn from "../common/button/EnterChatRoomBtn";
 
 const EnterChatRoom = ({
@@ -42,11 +42,7 @@ const EnterChatRoom = ({
 
   if (filteredPostData.length === 0) {
     return (
-      <BasicModal
-        message="해당하는 채팅방이 없어요"
-        closeModal={closeModal}
-        confirm={closeModal}
-      />
+      <AlertModal message="해당하는 채팅방이 없어요" closeModal={closeModal} />
     );
   }
 

--- a/src/components/modal/NotificationEnterChatRoom.tsx
+++ b/src/components/modal/NotificationEnterChatRoom.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 import { MdOutlineClose } from "react-icons/md";
 import useFetchData from "../../hooks/useFetchData";
-import BasicModal from "./BasicModal";
+import AlertModal from "./AlertModal";
 import EnterChatRoomBtn from "../common/button/EnterChatRoomBtn";
 import { useRecoilValue } from "recoil";
 import { accessTokenState } from "../../states/recoil";
@@ -34,11 +34,7 @@ const NotificationEnterChatRoom = ({
 
   if (notificationData.length <= 0) {
     return (
-      <BasicModal
-        message="해당하는 채팅방이 없어요"
-        closeModal={closeModal}
-        confirm={closeModal}
-      />
+      <AlertModal message="해당하는 채팅방이 없어요" closeModal={closeModal} />
     );
   }
 

--- a/src/views/LoginCallbackPage.tsx
+++ b/src/views/LoginCallbackPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { accessTokenState, userInfoState } from "../states/recoil";
 import { useSetRecoilState } from "recoil";
-import BasicModal from "../components/modal/BasicModal";
+import AlertModal from "../components/modal/AlertModal";
 import { UserInfoState } from "../states/recoilType";
 import axios from "axios";
 
@@ -66,19 +66,17 @@ const LoginCallbackPage = () => {
       ) : (
         <>
           {showErrorModal && (
-            <BasicModal
+            <AlertModal
               message="로그인을 다시 시도해 주세요"
               closeModal={closeErrorModal}
-              confirm={closeErrorModal}
             />
           )}
         </>
       )}
       {showWelcomeModal && (
-        <BasicModal
+        <AlertModal
           message="반가워요! 로그인 되었어요."
           closeModal={closeWelcomeModal}
-          confirm={closeWelcomeModal}
         />
       )}
     </>

--- a/src/views/MemberPage.tsx
+++ b/src/views/MemberPage.tsx
@@ -1,10 +1,10 @@
 import { Suspense, lazy, useState, Dispatch, SetStateAction } from "react";
 import { useNavigate } from "react-router-dom";
+import { useRecoilState, useRecoilValue, useResetRecoilState } from "recoil";
 import ChangeNickname from "../components/modal/ChangeNickname";
 import LoadPostCard from "../components/skeletonUI/LoadPostCard";
 import { ErrorBoundary } from "react-error-boundary";
 import ErrorMessage from "../components/common/ErrorMessage";
-import { useRecoilState, useRecoilValue } from "recoil";
 import { accessTokenState, userInfoState } from "../states/recoil";
 import ScrollTopBtn from "../components/common/button/ScrollTopBtn";
 import { UserInfoState } from "../states/recoilType";
@@ -24,6 +24,7 @@ const MemberPage = (): JSX.Element => {
   const [token, setToken] = useRecoilState<string>(accessTokenState);
   const userInfo = useRecoilValue<UserInfoState>(userInfoState);
   const nickname = userInfo.nickname;
+  const resetUserInfo = useResetRecoilState(userInfoState);
   const navigate = useNavigate();
 
   const PostCardList = lazy(
@@ -31,8 +32,8 @@ const MemberPage = (): JSX.Element => {
   );
 
   const LogoutClick = () => {
+    resetUserInfo();
     setToken("");
-    sessionStorage.removeItem("user");
     closeModal(setShowConfirmModal);
     navigate("/");
   };

--- a/src/views/MemberPage.tsx
+++ b/src/views/MemberPage.tsx
@@ -8,7 +8,7 @@ import { useRecoilState, useRecoilValue } from "recoil";
 import { accessTokenState, userInfoState } from "../states/recoil";
 import ScrollTopBtn from "../components/common/button/ScrollTopBtn";
 import { UserInfoState } from "../states/recoilType";
-import BasicModal from "../components/modal/BasicModal";
+import ConfirmModal from "../components/modal/ConfirmModal";
 
 const sortNames = [
   { name: "작성한 투표글", sort: "POSTS" },
@@ -96,7 +96,7 @@ const MemberPage = (): JSX.Element => {
         />
       ) : null}
       {showConfirmModal && (
-        <BasicModal
+        <ConfirmModal
           message="로그아웃 할까요?"
           closeModal={() => closeModal(setShowConfirmModal)}
           confirm={LogoutClick}


### PR DESCRIPTION
## PR Type
- [ ] Feat: 새로운 기능 구현
- [x] Fix: 버그 수정
- [ ] Docs: 문서 추가 및 수정
- [ ] Style: 코드 포맷 변경
- [ ] Design: css 및 UI 관련 변경
- [x] Refactor: 코드 리팩토링
- [ ] Rename: 폴더/파일 이름 및 위치 변경
- [ ] Test: 테스트 관련
- [ ] Deploy: 배포 관련
- [ ] Chore: 빌드, 환경 설정 등 기타 작업
- [ ] Add: 기능 구현 외 추가 사항

## Abstracts
* BasicModal을 ConfrimModal과 AlertModal로 분리, 로그아웃 후 댓글 삭제 버튼 뜨는 오류 수정

## Description
- Basic모달을 confirm과 alert 상황에 맞게 사용할 수 있도록 수정
- 로그아웃 시 userInfoState를 default값으로 reset
- 댓글 삭제 버튼 렌더링 조건으로 token 여부 추가

![Confirm모달](https://github.com/winnow-2023/best-choice-fe/assets/123265266/07773928-c083-4f61-9022-9bd26373710c)

## Discussion
* 로그아웃 후에도 댓글 삭제 버튼이 뜨는 오류는 userInfoState reset과 삭제 버튼 렌더링 조건 수정 중 하나만 해도 해결되긴 하지만 추후 발생할 수 있는 오류 방지 겸 확실하게 하고자 두 가지 모두 적용했습니다!

---
Close  #113 #114 
